### PR TITLE
First pass at working references for includes

### DIFF
--- a/src/com/intellij/plugins/thrift/lang/psi/ThriftIncludeReference.java
+++ b/src/com/intellij/plugins/thrift/lang/psi/ThriftIncludeReference.java
@@ -1,0 +1,27 @@
+package com.intellij.plugins.thrift.lang.psi;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.plugins.thrift.util.ThriftPsiUtil;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReferenceBase;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ThriftIncludeReference extends PsiReferenceBase<ThriftInclude> {
+  public ThriftIncludeReference(@NotNull ThriftInclude element) {
+    // 8 = start of name in quotes, after 'include '. Hack to avoid negative length range during autocomplete
+    super(element, new TextRange(element.getTextLength() < 8 ? 0 : 8, element.getTextLength()));
+  }
+
+  @Nullable
+  @Override
+  public PsiElement resolve() {
+    return ThriftPsiUtil.resolveInclude(getElement());
+  }
+
+  @NotNull
+  @Override
+  public Object[] getVariants() {
+    return PsiElement.EMPTY_ARRAY;
+  }
+}

--- a/src/com/intellij/plugins/thrift/util/ThriftPsiUtil.java
+++ b/src/com/intellij/plugins/thrift/util/ThriftPsiUtil.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -73,7 +74,10 @@ public class ThriftPsiUtil {
 
   @NotNull
   public static PsiReference[] getReferences(@NotNull ThriftInclude include) {
-    return getReferenceSet(include).getAllReferences();
+    final List<PsiReference> refs = new ArrayList<PsiReference>();
+    refs.addAll(Arrays.asList(getReferenceSet(include).getAllReferences()));
+    refs.add(new ThriftIncludeReference(include));
+    return refs.toArray(new PsiReference[]{});
   }
 
   @NotNull


### PR DESCRIPTION
Added a new Reference type for includes that actually. Warning:
![](http://www.quickmeme.com/img/d6/d6a1143f571184db25f94613edd43b40af6d3a629221aba00d9efdcfef5efd84.jpg)

Kept the existing FileReferenceStuff there because autocomplete depends on it (and thus one of the tests), even though include autocomplete in real projects is pretty broken because it only seems to search the same directory.

