### PR TITLE
Add support for generated_annotations=undated

### DIFF
--- a/plugin-jps/src/com/intellij/plugins/thrift/config/target/Java.java
+++ b/plugin-jps/src/com/intellij/plugins/thrift/config/target/Java.java
@@ -50,6 +50,11 @@ public class Java extends Generator {
    */
   private boolean reuseObjects;
 
+  /**
+   * Generated annotations will be undated to avoid unnecessary changes in source tree
+   */
+  private boolean undatedAnnotations;
+
   protected Java() {
     super(GeneratorType.Java);
   }
@@ -94,6 +99,10 @@ public class Java extends Generator {
     this.reuseObjects = reuseObjects;
   }
 
+  public void setUndatedAnnotations(boolean undatedAnnotations) {
+    this.undatedAnnotations = undatedAnnotations;
+  }
+
   public boolean isBeans() {
     return beans;
   }
@@ -134,6 +143,10 @@ public class Java extends Generator {
     return reuseObjects;
   }
 
+  public boolean isUndatedAnnotations() {
+    return undatedAnnotations;
+  }
+
   @Override
   protected Collection<String> getOptions() {
     ArrayList<String> line = new ArrayList<String>();
@@ -166,6 +179,9 @@ public class Java extends Generator {
     }
     if (reuseObjects) {
       line.add("reuse-objects");
+    }
+    if (undatedAnnotations) {
+      line.add("generated_annotations=undated");
     }
     return line;
   }

--- a/src/com/intellij/plugins/thrift/ThriftBundle.properties
+++ b/src/com/intellij/plugins/thrift/ThriftBundle.properties
@@ -79,6 +79,7 @@ thrift.gen.option.package=Package name (default\: inferred from thrift file name
 thrift.gen.option.fullcamel=Convert underscored_accessor_or_service_names to camelCase (v0.9.2)
 thrift.gen.option.android=Generated structures are Parcelable (0.9.2)
 thrift.gen.option.reuse-objects=Data objects will not be allocated, but existing instances will be used (read and write) (v0.9.2)
+thrift.gen.option.undated-annotations=Generated annotations will be undated to avoid unnecessary changes in source tree
 thrift.gen.option.ts=Generate TypeScript definition files (v0.9.2)
 thrift.gen.option.validate=Generate PHP validator methods (v0.9.2)
 thrift.gen.option.json=Generate JsonSerializable classes (requires PHP >\= 5.4) (v0.9.2)

--- a/src/com/intellij/plugins/thrift/config/facet/options/JavaOptionPane.java
+++ b/src/com/intellij/plugins/thrift/config/facet/options/JavaOptionPane.java
@@ -23,6 +23,7 @@ class JavaOptionPane extends AOptionPane<Java> {
   private final JCheckBox myFullcamel;
   private final JCheckBox myAndroid;
   private final JCheckBox myReuseObjects;
+  private final JCheckBox myUndatedAnnotations;
 
   public JavaOptionPane() {
     super(new GridLayout(0, 1));
@@ -37,6 +38,7 @@ class JavaOptionPane extends AOptionPane<Java> {
     myFullcamel = new JCheckBox(ThriftBundle.message("thrift.gen.option.fullcamel"));
     myAndroid = new JCheckBox(ThriftBundle.message("thrift.gen.option.android"));
     myReuseObjects = new JCheckBox(ThriftBundle.message("thrift.gen.option.reuse-objects"));
+    myUndatedAnnotations = new JCheckBox(ThriftBundle.message("thrift.gen.option.undated-annotations"));
 
     add(myBeans);
     add(myPrivateMembers);
@@ -48,6 +50,7 @@ class JavaOptionPane extends AOptionPane<Java> {
     add(myFullcamel);
     add(myAndroid);
     add(myReuseObjects);
+    add(myUndatedAnnotations);
   }
 
   @Override
@@ -62,6 +65,7 @@ class JavaOptionPane extends AOptionPane<Java> {
     myFullcamel.setSelected(java.isFullcamel());
     myAndroid.setSelected(java.isAndroid());
     myReuseObjects.setSelected(java.isReuseObjects());
+    myUndatedAnnotations.setSelected(java.isUndatedAnnotations());
   }
 
   @Override
@@ -76,5 +80,6 @@ class JavaOptionPane extends AOptionPane<Java> {
     java.setFullcamel(myFullcamel.isSelected());
     java.setAndroid(myAndroid.isSelected());
     java.setReuseObjects(myReuseObjects.isSelected());
+    java.setUndatedAnnotations(myUndatedAnnotations.isSelected());
   }
 }


### PR DESCRIPTION
Please consider adding this feature. This is very useful when generated classes are committed to source tree (our development workflow requires this).

This is to avoid committing all generated classes just because of build timestamp change.

Thank you for the awesome plugin!
