### PR TITLE
Fix relative imports

### DIFF
--- a/src/com/intellij/plugins/thrift/util/ThriftPsiUtil.java
+++ b/src/com/intellij/plugins/thrift/util/ThriftPsiUtil.java
@@ -82,12 +82,7 @@ public class ThriftPsiUtil {
     final String path = getPath(include);
     return new FileReferenceSet(
       path, include, element.getStartOffsetInParent() + 1, null, true, true, new FileType[]{ThriftFileType.INSTANCE}
-    ) {
-      @Override
-      public boolean isAbsolutePathReference() {
-        return true;
-      }
-    };
+    );
   }
 
   @NotNull


### PR DESCRIPTION
Fixes #48 
Alternatively we can obtain two separate sets for `true` and `false` versions and merge them.