### PR TITLE
Request ThriftPlugin via getComponent instead of getService.

### DIFF
--- a/src/com/intellij/plugins/thrift/config/ThriftCompilerConfigurable.java
+++ b/src/com/intellij/plugins/thrift/config/ThriftCompilerConfigurable.java
@@ -75,7 +75,7 @@ public class ThriftCompilerConfigurable extends BaseConfigurable implements Sear
   @Override
   public JComponent createComponent() {
     if (configForm == null) {
-      ThriftPlugin plugin = ServiceManager.getService(project, ThriftPlugin.class);
+      ThriftPlugin plugin = project.getComponent(ThriftPlugin.class);
       configForm = new ThriftConfigForm(plugin);
     }
     return configForm;


### PR DESCRIPTION
IntelliJ 2019.3 EAP logs a PluginError otherwise. The behavior is the
same, as getService falls back to getComponent.

fixes fkorotkov/intellij-thrift/#77