### PR TITLE
Move Icon loading outside GeneratorType class [2019.3]

### DIFF
--- a/plugin-jps/src/com/intellij/plugins/thrift/config/target/GeneratorType.java
+++ b/plugin-jps/src/com/intellij/plugins/thrift/config/target/GeneratorType.java
@@ -106,24 +106,19 @@ public enum GeneratorType {
   XSD("xsd", "/fileTypes/xsdFile.png"),
   //---
   ;
-  private final Icon myIcon;
+  private final String iconName;
   protected final String name;
 
   GeneratorType(String name, final String iconName) {
     this.name = name;
-    myIcon = new IconLoader.LazyIcon() {
-      @Override
-      protected Icon compute() {
-        return IconLoader.getIcon(iconName);
-      }
-    };
+    this.iconName = iconName;
   }
 
   public Generator create() {
     return new Generator(this);
   }
 
-  public Icon getIcon() {
-    return myIcon;
+  public String getIconName(){
+    return iconName;
   }
 }

--- a/src/com/intellij/plugins/thrift/GeneratorIcons.java
+++ b/src/com/intellij/plugins/thrift/GeneratorIcons.java
@@ -7,7 +7,7 @@ import javax.swing.*;
 import java.util.HashMap;
 import java.util.Map;
 
-public class GeneratorIcons {
+public final class GeneratorIcons {
 
   public static Icon getIcon(GeneratorType generatorType) {
     return LazyHolder.INSTANCE.getIconInstance(generatorType);
@@ -24,13 +24,15 @@ public class GeneratorIcons {
   private Map<GeneratorType, IconLoader.LazyIcon> icons = new HashMap<GeneratorType, IconLoader.LazyIcon>();
 
   private GeneratorIcons() {
+
     for (final GeneratorType generatorType : GeneratorType.values()) {
-      icons.put(generatorType, new IconLoader.LazyIcon() {
+      IconLoader.LazyIcon lazyIcon = new IconLoader.LazyIcon() {
         @Override
         protected Icon compute() {
           return IconLoader.getIcon(generatorType.getIconName());
         }
-      });
+      };
+      icons.put(generatorType, lazyIcon);
     }
   }
 }

--- a/src/com/intellij/plugins/thrift/GeneratorIcons.java
+++ b/src/com/intellij/plugins/thrift/GeneratorIcons.java
@@ -1,0 +1,36 @@
+package com.intellij.plugins.thrift;
+
+import com.intellij.openapi.util.IconLoader;
+import com.intellij.plugins.thrift.config.target.GeneratorType;
+
+import javax.swing.*;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GeneratorIcons {
+
+  public static Icon getIcon(GeneratorType generatorType) {
+    return LazyHolder.INSTANCE.getIconInstance(generatorType);
+  }
+
+  private Icon getIconInstance(GeneratorType generatorType) {
+    return this.icons.get(generatorType);
+  }
+
+  private static class LazyHolder {
+    static final GeneratorIcons INSTANCE = new GeneratorIcons();
+  }
+
+  private Map<GeneratorType, IconLoader.LazyIcon> icons = new HashMap<GeneratorType, IconLoader.LazyIcon>();
+
+  private GeneratorIcons() {
+    for (final GeneratorType generatorType : GeneratorType.values()) {
+      icons.put(generatorType, new IconLoader.LazyIcon() {
+        @Override
+        protected Icon compute() {
+          return IconLoader.getIcon(generatorType.getIconName());
+        }
+      });
+    }
+  }
+}

--- a/src/com/intellij/plugins/thrift/config/facet/ThriftFacetConf.java
+++ b/src/com/intellij/plugins/thrift/config/facet/ThriftFacetConf.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.util.WriteExternalException;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.plugins.thrift.GeneratorIcons;
 import com.intellij.plugins.thrift.ThriftBundle;
 import com.intellij.plugins.thrift.config.ThriftCompilerOptions;
 import com.intellij.plugins.thrift.config.facet.options.OptionsDialogWrapper;
@@ -238,7 +239,7 @@ public class ThriftFacetConf implements FacetConfiguration, PersistentStateCompo
             assert value != null;
 
             GeneratorType type = (GeneratorType)value;
-            setIcon(type.getIcon());
+            setIcon(GeneratorIcons.getIcon(type));
             append(type.name(), SimpleTextAttributes.REGULAR_ATTRIBUTES);
           }
         });
@@ -339,7 +340,7 @@ public class ThriftFacetConf implements FacetConfiguration, PersistentStateCompo
         private final GeneratorType myType;
 
         public CreateGeneratorAction(GeneratorType type) {
-          super(type.name(), "", type.getIcon());
+          super(type.name(), "", GeneratorIcons.getIcon(type));
           myType = type;
         }
 


### PR DESCRIPTION
New IntelliJ versions do not include IconLoader in JPS plugins' classpath, so the GeneratorType (used inside the JPS plugin) must not be dependent on IconLoader.

Moved Icon loading to a constant singleton class GeneratorIcons.

fixes #79