### PR TITLE
Do not call Vfs functions in JPS module [2019.3]

### DIFF
--- a/plugin-jps/src/com/intellij/plugins/thrift/jps/ThriftBuilder.java
+++ b/plugin-jps/src/com/intellij/plugins/thrift/jps/ThriftBuilder.java
@@ -3,7 +3,6 @@ package com.intellij.plugins.thrift.jps;
 import com.intellij.execution.process.BaseOSProcessHandler;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
-import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.plugins.thrift.config.ThriftCompilerOptions;
 import com.intellij.plugins.thrift.config.ThriftConfig;
 import com.intellij.plugins.thrift.config.target.Generator;
@@ -21,6 +20,7 @@ import org.jetbrains.jps.model.module.JpsModule;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -46,7 +46,7 @@ public class ThriftBuilder extends ModuleLevelBuilder {
                         ModuleLevelBuilder.OutputConsumer outputConsumer) throws ProjectBuildException, IOException {
     ThriftConfig thriftConfig = ThriftConfig.getSettings(context.getProjectDescriptor().getProject());
 
-    final String compiler = VfsUtil.urlToPath(thriftConfig.getCompilerPath());
+    final String compiler = thriftConfig.getCompilerPath();
 
     final Map<ModuleBuildTarget, List<File>> toCompile = collectChangedFiles(dirtyFilesHolder);
 
@@ -106,7 +106,7 @@ public class ThriftBuilder extends ModuleLevelBuilder {
         genCmdLine.add(g.getOptionsString());
         genCmdLine.add("-out");
 
-        final String path = VfsUtil.urlToPath(g.getOutputDir());
+        final String path = new URL(g.getOutputDir()).getPath();
         genCmdLine.add(path);
         final File targetDir = new File(path);
 


### PR DESCRIPTION
New IntelliJ version (2019.3) doesn't allow to call Vfs functions in
JPS module. This means that the paths has to be converted to URLs
during configuration.

There's no need to call `urlToPath` in ThriftBuilder because:

1. compilerPath is now passed to ThriftConfig constructor as URL

2. outputDir was already crated as URL:
```
      final String url = VfsUtil.pathToUrl(dir);
      final VirtualFile file = VirtualFileManager.getInstance().findFileByUrl(url);

      myGenerator.setOutputDir(file == null ? url : file.getUrl());
```

fixes #76