### PR TITLE
Adapt to idea 2020.1 API changes

### DIFF
--- a/jps-plugin/src/main/java/com/intellij/plugins/thrift/config/ThriftCompilerOptions.java
+++ b/jps-plugin/src/main/java/com/intellij/plugins/thrift/config/ThriftCompilerOptions.java
@@ -1,7 +1,7 @@
 package com.intellij.plugins.thrift.config;
 
 import com.intellij.plugins.thrift.config.target.*;
-import com.intellij.util.xmlb.annotations.AbstractCollection;
+import com.intellij.util.xmlb.annotations.XCollection;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.jps.model.JpsElementChildRole;
 import org.jetbrains.jps.model.ex.JpsElementBase;
@@ -29,8 +29,7 @@ public class ThriftCompilerOptions extends JpsElementBase<ThriftCompilerOptions>
     return config == null ? new ThriftCompilerOptions() : config;
   }
 
-  @AbstractCollection(
-    surroundWithTag = false,
+  @XCollection(
     elementTypes = {AS3.class, Cocoa.class, Cpp.class, CSharp.class, Delphi.class, Erlang.class, Generator.class, Go.class, Graphviz.class,
       HTML.class, IGenerator.class, Java.class, Javascript.class, PHP.class, Python.class, Ruby.class}
   )

--- a/thrift/src/main/resources/META-INF/plugin.xml
+++ b/thrift/src/main/resources/META-INF/plugin.xml
@@ -105,7 +105,7 @@
       ]]>
   </change-notes>
   <vendor>@fedor</vendor>
-  <idea-version since-build="201"/><!-- Will be patched by the plugin -->
+  <idea-version since-build="192"/><!-- Will be patched by the plugin -->
 
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>

--- a/thrift/src/main/resources/META-INF/plugin.xml
+++ b/thrift/src/main/resources/META-INF/plugin.xml
@@ -105,7 +105,7 @@
       ]]>
   </change-notes>
   <vendor>@fedor</vendor>
-  <idea-version since-build="192"/><!-- Will be patched by the plugin -->
+  <idea-version since-build="201"/><!-- Will be patched by the plugin -->
 
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
This adapts to the changes made in the new idea versions:
1. `com.intellij.util.xmlb.annotations.AbstractCollection` got deprecated, using `com.intellij.util.xmlb.annotations.XCollection` is now recommended. The `surroundWithTag = false` parameter was just dropped whenever it was used within jetbrains repository, so I followed the same approach.
2. Extending `com.intellij.plugins.thrift.jps.ModuleLevelBuilder` now requires implementing the`getCompilableFileExtensions` method, which in most implementations within jetbrains repository just returns an empty list.