### PR TITLE
Fix jps jar name to match plugin.xml

### DIFF
--- a/jps-plugin/build.gradle
+++ b/jps-plugin/build.gradle
@@ -1,1 +1,1 @@
-jar.archiveName = "jps-plugin.jar"
+jar.archiveName = "thrift-jps.jar"


### PR DESCRIPTION
It seems like an obvious bug. Intellij fails for me as it tries to load lib/thrift-jps.jar as stated in plugin.xml, but the actual jar that is there is jps-plugin.jar.