### PR TITLE
Revert file type registration change

### DIFF
--- a/thrift/src/main/java/com/intellij/plugins/thrift/ThriftFileTypeLoader.java
+++ b/thrift/src/main/java/com/intellij/plugins/thrift/ThriftFileTypeLoader.java
@@ -1,0 +1,15 @@
+package com.intellij.plugins.thrift;
+
+import com.intellij.openapi.fileTypes.FileTypeConsumer;
+import com.intellij.openapi.fileTypes.FileTypeFactory;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Created by fkorotkov.
+ */
+public class ThriftFileTypeLoader extends FileTypeFactory {
+  @Override
+  public void createFileTypes(@NotNull FileTypeConsumer fileTypeConsumer) {
+    fileTypeConsumer.consume(ThriftFileType.INSTANCE);
+  }
+}

--- a/thrift/src/main/resources/META-INF/plugin.xml
+++ b/thrift/src/main/resources/META-INF/plugin.xml
@@ -122,7 +122,7 @@
     <!-- Add your application components here -->
   </application-components>
   <extensions defaultExtensionNs="com.intellij">
-    <fileType name="Thrift" extensions="thrift" language="thrift" implementationClass="com.intellij.plugins.thrift.ThriftFileType"/>
+    <fileTypeFactory implementation="com.intellij.plugins.thrift.ThriftFileTypeLoader"/>
     <lang.parserDefinition language="thrift" implementationClass="com.intellij.plugins.thrift.lang.parser.ThriftParserDefinition"/>
     <completion.contributor language="any" implementationClass="com.intellij.plugins.thrift.completion.ThriftKeywordCompletionContributor"/>
     <itemPresentationProvider forClass="com.intellij.plugins.thrift.lang.psi.ThriftTopLevelDeclaration"


### PR DESCRIPTION
Hi!
I have run tests we have in pants plugin https://github.com/pantsbuild/intellij-pants-plugin/pull/553 with thrift 1.2 and one of them failed. I reproduced locally that find class window in 1.2, when you look for a thrift struct, only shows the generated java class but doesn't show the actual thrift struct. This is super strange, because I don't see anything wrong in the change I reverted here, but it is actually fixes this issue.

![Zrzut ekranu z 2020-07-31 11-16-19](https://user-images.githubusercontent.com/10235198/89024846-11daee80-d326-11ea-8f58-ae7f3cf40249.png)
