### PR TITLE
Java 8 target for JPS plugins

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 container:
-  image: openjdk:8
+  image: openjdk:11
 
 task:
   name: Tests

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,10 @@
 container:
-  image: gradle:jdk11
+  image: openjdk:8
 
 task:
   name: Tests
-  build_script: gradle classes testClasses
-  test_script: gradle test
+  build_script: ./gradlew classes testClasses
+  test_script: ./gradlew test
 
 task:
   name: Publish
@@ -12,4 +12,4 @@ task:
   depends_on: Tests
   env:
     JETBRAINS_TOKEN: ENCRYPTED[260a01be940eee2f33c35c8f069067b73c34244f297088843ad96d21c4062469d3628989d768056a5e42eb4e07f31c6b]
-  test_script: gradle :thrift:publishPlugin
+  test_script: ./gradlew :thrift:publishPlugin

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,7 @@
 plugins {
-    id "org.jetbrains.intellij" version "0.6.1"
+    id "org.jetbrains.intellij" version "0.6.5"
 }
 
-version = "${version}.$buildNumber"
 subprojects {
     apply plugin: 'java'
     tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
-ideaVersion = 203-EAP-SNAPSHOT
-buildNumber = SNAPSHOT
+ideaVersion = IC-2020.3.1
 sources = true
 isEAP = false
 

--- a/jps-plugin/build.gradle
+++ b/jps-plugin/build.gradle
@@ -1,1 +1,5 @@
 jar.archiveName = "thrift-jps.jar"
+
+java {
+    targetCompatibility = JavaVersion.VERSION_1_8
+}

--- a/jps-plugin/build.gradle
+++ b/jps-plugin/build.gradle
@@ -1,5 +1,6 @@
 jar.archiveName = "thrift-jps.jar"
 
 java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }


### PR DESCRIPTION
Not sure why but it seems it should fix #101. Still unclear why folks in the issue need Java 8 when IntelliJ bundles Java 11. Let's see if this change will fix it!