### PR TITLE
IntelliJ 2021.3 Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ subprojects {
     apply plugin: 'org.jetbrains.intellij'
     intellij {
         version project.property("ideaVersion")
-        plugins = ['copyright', 'java', 'org.intellij.scala:2021.1.16']
+        plugins = ['copyright', 'java', 'org.intellij.scala:2021.3.14']
         downloadSources Boolean.valueOf(sources)
         sameSinceUntilBuild Boolean.valueOf(isEAP)
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-ideaVersion = 2021.2
+ideaVersion = 2021.3
 sources = true
 isEAP = false
 

--- a/thrift/src/main/java/com/intellij/plugins/thrift/editor/ThriftLineMarkerProvider.java
+++ b/thrift/src/main/java/com/intellij/plugins/thrift/editor/ThriftLineMarkerProvider.java
@@ -43,7 +43,6 @@ public class ThriftLineMarkerProvider implements LineMarkerProvider {
       definitionName,
       definitionName.getTextRange(),
       AllIcons.Gutter.ImplementedMethod,
-      Pass.UPDATE_ALL,
       new Function<PsiElement, String>() {
         @Override
         public String fun(PsiElement element) {
@@ -62,7 +61,8 @@ public class ThriftLineMarkerProvider implements LineMarkerProvider {
           );
         }
       },
-      GutterIconRenderer.Alignment.RIGHT
+      GutterIconRenderer.Alignment.RIGHT,
+      () -> DaemonBundle.message("interface.is.implemented.too.many")
     );
   }
 }


### PR DESCRIPTION
Appears to build and run successfully locally.

The change to `ThriftLineMarkerProvider.java` is resolving a deprecation warning - can revert if this is incorrect.