### PR TITLE
fix build: remove deprecated bintray repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ subprojects {
         mavenCentral()
         maven { setUrl("https://repo.gradle.org/gradle/repo") }
         maven { setUrl("https://maven.google.com/") }
-        maven { setUrl("https://dl.bintray.com/cirruslabs/maven") }
     }
 
     apply plugin: 'org.jetbrains.intellij'


### PR DESCRIPTION
JFrog has announced that they are shutting down the Bintray hosting service, which includes the popular JCenter hosting service for Java artifacts (more detail can be found [here](
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)).

This PR is to remove deprecated bintray repo.

| [Before](https://cirrus-ci.com/task/5128039618052096?logs=build#L25) | [After](https://cirrus-ci.com/task/4798295255023616?logs=build#L14) |
| --- | --- |
|![image](https://user-images.githubusercontent.com/15963765/145936237-5fc52ded-43f2-489c-9efa-6695c11f213f.png)|![image](https://user-images.githubusercontent.com/15963765/145936277-e84a3827-c661-4604-b7c8-8a821e642fc6.png)|

